### PR TITLE
docs: fix license badge, layer numbering, missing JSDoc, and env var table

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ cp .env.example .env
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL |
 | `OLLAMA_MODEL` | `qwen3:1.7b` | Any Ollama-supported model |
 | `OLLAMA_CTX_SIZE` | `4096` | Context window (lower = less RAM) |
 | `AGENT_TIMEOUT` | `300` | Max seconds per agent run |
+| `AGENT_OUTPUT_DIR` | `outputs` | Directory for agent output files |
 
 ### Model Options
 

--- a/config/agent-config.ts
+++ b/config/agent-config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 
+/** Configuration for a single agent, resolved from env vars and defaults. */
 export interface AgentConfig {
   name: string;
   description: string;
@@ -42,6 +43,13 @@ export const agents: Record<string, AgentConfig> = {
   },
 };
 
+/**
+ * Retrieve the resolved configuration for a named agent.
+ *
+ * @param name - Agent key (e.g. `'qa'`, `'report'`, `'prototype'`).
+ * @returns The agent's `AgentConfig`.
+ * @throws If no agent with the given name is registered.
+ */
 export function getAgent(name: string): AgentConfig {
   const config = agents[name];
   if (!config) {
@@ -51,6 +59,10 @@ export function getAgent(name: string): AgentConfig {
   return config;
 }
 
+/**
+ * Load environment variables from `.env` into `process.env`.
+ * Existing env vars are never overwritten. Silently no-ops if `.env` is absent.
+ */
 export function loadEnv(): void {
   const envPath = resolve(ROOT, '.env');
   if (!existsSync(envPath)) return;

--- a/config/ollama.ts
+++ b/config/ollama.ts
@@ -4,6 +4,7 @@ const OLLAMA_HOST = process.env.OLLAMA_HOST || 'http://localhost:11434';
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'qwen3:1.7b';
 const OLLAMA_CTX_SIZE = parseInt(process.env.OLLAMA_CTX_SIZE || '4096', 10);
 
+/** Options for a generation request sent to Ollama. */
 export interface OllamaRequest {
   prompt: string;
   model?: string;
@@ -11,6 +12,7 @@ export interface OllamaRequest {
   temperature?: number;
 }
 
+/** Parsed response returned from an Ollama generation request. */
 export interface OllamaResponse {
   text: string;
   model: string;
@@ -19,6 +21,14 @@ export interface OllamaResponse {
   responseTokens: number;
 }
 
+/**
+ * Send a generation request to the local Ollama instance.
+ * Automatically optimizes the prompt via the memory layer and records token usage.
+ *
+ * @param req - Prompt, optional model override, optional system prompt, and temperature.
+ * @returns Parsed response including generated text and token counts.
+ * @throws If Ollama returns a non-OK HTTP status.
+ */
 export async function generate(req: OllamaRequest): Promise<OllamaResponse> {
   const prompt = await optimizePrompt(req.prompt);
 
@@ -62,6 +72,10 @@ export async function generate(req: OllamaRequest): Promise<OllamaResponse> {
   return result;
 }
 
+/**
+ * Check whether the local Ollama server is reachable.
+ * @returns `true` if Ollama responds to a tags request, `false` otherwise.
+ */
 export async function isOllamaRunning(): Promise<boolean> {
   try {
     const res = await fetch(`${OLLAMA_HOST}/api/tags`);
@@ -71,6 +85,10 @@ export async function isOllamaRunning(): Promise<boolean> {
   }
 }
 
+/**
+ * List the names of all models currently available in Ollama.
+ * @returns Array of model name strings, or an empty array if the request fails.
+ */
 export async function listModels(): Promise<string[]> {
   const res = await fetch(`${OLLAMA_HOST}/api/tags`);
   if (!res.ok) return [];

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,11 @@ Policy-as-code enforcement via `agentguard.yaml`.
 Currently in `monitor` mode — logs all actions, blocks nothing.
 Switch to `enforce` when policies are battle-tested.
 
-### Layer 2 — Agent Logic
+### Layer 2 — Model (Ollama)
+Local LLM serving via Ollama. Default model: `qwen3:1.7b` (1.7B params, ~1GB RAM).
+Swap to any Ollama-supported model by changing `OLLAMA_MODEL` in `.env`.
+
+### Layer 3 — Agent Logic
 Simple TypeScript scripts. Each agent:
 1. Reads input (files, git log, user prompt)
 2. Constructs a system + user prompt
@@ -52,10 +56,6 @@ Simple TypeScript scripts. Each agent:
 4. Saves output to `outputs/`
 
 No frameworks, no daemons, no state between runs.
-
-### Layer 3 — Model (Ollama)
-Local LLM serving via Ollama. Default model: `qwen3:1.7b` (1.7B params, ~1GB RAM).
-Swap to any Ollama-supported model by changing `OLLAMA_MODEL` in `.env`.
 
 ## Data Flow
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -387,7 +387,7 @@
 <!-- ─── Hero ─── -->
 <section class="hero">
   <div class="container">
-    <div class="hero-badge">Open Source · Apache 2.0 · <strong>Built for Apple Silicon</strong></div>
+    <div class="hero-badge">Open Source · MIT License · <strong>Built for Apple Silicon</strong></div>
     <h1>
       <span class="fire">Forge</span> Local AI Agents.<br>
       Governed.


### PR DESCRIPTION
## Summary

Routine documentation audit of ShellForge. Four categories of fixes.

### Changes

| File | Issue | Fix |
|------|-------|-----|
| `docs/index.html` | Hero badge said "Apache 2.0" — license is MIT (footer was already correct) | Changed to "MIT License" |
| `docs/architecture.md` | Layer 2/3 labels swapped vs `index.html` — Ollama and Agent Logic were in wrong order | Swapped to match index.html (Layer 2 = Ollama, Layer 3 = Agent Logic) |
| `config/ollama.ts` | Exported interfaces and functions had no JSDoc | Added JSDoc for `OllamaRequest`, `OllamaResponse`, `generate()`, `isOllamaRunning()`, `listModels()` |
| `config/agent-config.ts` | Exported interface and functions had no JSDoc | Added JSDoc for `AgentConfig`, `getAgent()`, `loadEnv()` |
| `README.md` | Config table was missing `OLLAMA_HOST` and `AGENT_OUTPUT_DIR` (both present in `.env.example` and code) | Added both rows |

### Verification

- `tsc --noEmit` passes (no type errors)
- No logic changes — JSDoc and doc-only edits

---

**Governance report:** documentation-only PR, no behavioral changes, no secrets, no force-push, scoped to single repo.

_Generated by Copilot documentation maintainer agent_