### PR TITLE
feat: full-stack ecosystem diagram + RTK/TurboQuant on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -545,45 +545,110 @@
 <!-- ─── Ecosystem ─── -->
 <section class="ecosystem" id="ecosystem">
   <div class="container">
-    <h2 class="section-title">Part of Something Bigger</h2>
-    <p class="section-sub">ShellForge is one piece of the governed agentic AI stack.</p>
-    <div class="ecosystem-grid">
+    <h2 class="section-title">The Full Stack</h2>
+    <p class="section-sub">Eight technologies. One governed agent runtime. Here's how they fit together.</p>
+
+    <!-- Flow diagram -->
+    <div class="stack-diagram" style="margin-bottom: 50px;">
+      <div class="stack-layer" style="border-color: var(--accent); background: rgba(255,107,43,0.05);">
+        <span class="layer-tag" style="min-width: 80px;">INPUT</span>
+        <span class="layer-name">📝 Your Prompt</span>
+        <span class="layer-desc">"Analyze this repo for test gaps"</span>
+      </div>
+      <div class="stack-connector">↓</div>
+      <div class="stack-layer">
+        <span class="layer-tag" style="min-width: 80px; background: rgba(255,99,99,0.15); color: var(--red);">COMPRESS</span>
+        <span class="layer-name">⚡ RTK <span style="color:var(--muted);font-weight:400;font-size:0.85rem;">(Rust Token Killer)</span></span>
+        <span class="layer-desc">Strips 70-90% of terminal noise before the LLM sees it</span>
+      </div>
+      <div class="stack-connector">↓</div>
+      <div class="stack-layer">
+        <span class="layer-tag" style="min-width: 80px; background: rgba(177,151,252,0.15); color: var(--purple);">MEMORY</span>
+        <span class="layer-name">🧠 TurboQuant <span style="color:var(--muted);font-weight:400;font-size:0.85rem;">(Google, ICLR 2026)</span></span>
+        <span class="layer-desc">6x KV cache compression — run 14B models on 8GB Macs</span>
+      </div>
+      <div class="stack-connector">↓</div>
+      <div class="stack-layer">
+        <span class="layer-tag" style="min-width: 80px;">MODEL</span>
+        <span class="layer-name">🦙 Ollama</span>
+        <span class="layer-desc">Local inference — qwen3, mistral, any GGUF model</span>
+      </div>
+      <div class="stack-connector">↓</div>
+      <div class="stack-layer" style="border-color: var(--accent);">
+        <span class="layer-tag" style="min-width: 80px;">AGENT</span>
+        <span class="layer-name">🔥 ShellForge</span>
+        <span class="layer-desc">Agent execution loop — input → prompt → model → output → save</span>
+      </div>
+      <div class="stack-connector">↓</div>
+      <div class="stack-layer" style="border-color: var(--green);">
+        <span class="layer-tag" style="min-width: 80px; background: rgba(81,207,102,0.15); color: var(--green);">GOVERN</span>
+        <span class="layer-name">🛡️ AgentGuard</span>
+        <span class="layer-desc">Policy-as-code — allow/deny every tool call, full audit trail</span>
+      </div>
+      <div class="stack-connector">↓</div>
+      <div class="stack-layer" style="border-style: dashed; opacity: 0.8;">
+        <span class="layer-tag" style="min-width: 80px; background: rgba(77,171,247,0.15); color: var(--blue);">SCAN</span>
+        <span class="layer-name">🐾 DefenseClaw <span style="color:var(--muted);font-weight:400;font-size:0.85rem;">(Cisco, RSA 2026)</span></span>
+        <span class="layer-desc">Supply chain security — scan skills, verify MCP servers, AI BoM</span>
+      </div>
+      <div class="stack-connector">↓</div>
+      <div class="stack-layer" style="border-style: dashed; opacity: 0.8;">
+        <span class="layer-tag" style="min-width: 80px; background: rgba(255,159,28,0.15); color: var(--accent2);">SANDBOX</span>
+        <span class="layer-name">🔒 OpenShell <span style="color:var(--muted);font-weight:400;font-size:0.85rem;">(NVIDIA, GTC 2026)</span></span>
+        <span class="layer-desc">Kernel-level isolation — Landlock + Seccomp, signed audit logs</span>
+      </div>
+    </div>
+
+    <!-- Cards -->
+    <div class="ecosystem-grid" style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));">
       <div class="eco-card">
         <div class="eco-logo">🔥</div>
         <h4>ShellForge</h4>
-        <p>Local agent execution<br>Ollama + governance</p>
+        <p>Local agent runtime<br><strong>Runs the agents</strong></p>
       </div>
       <div class="eco-card">
         <div class="eco-logo">🛡️</div>
         <h4>AgentGuard</h4>
-        <p>Policy engine + hooks<br>Runtime governance</p>
+        <p>Policy engine + hooks<br><strong>Controls the agents</strong></p>
       </div>
-      <div class="eco-card eco-coming">
-        <div class="eco-logo">🔒</div>
-        <h4>OpenShell</h4>
-        <p>NVIDIA kernel sandbox<br>Layer 0 isolation</p>
+      <div class="eco-card">
+        <div class="eco-logo">🦙</div>
+        <h4>Ollama</h4>
+        <p>Local LLM serving<br><strong>Powers the agents</strong></p>
       </div>
-      <div class="eco-card eco-coming">
+      <div class="eco-card coming">
+        <div class="eco-logo">⚡</div>
+        <h4>RTK</h4>
+        <p>Rust Token Killer<br><strong>70-90% fewer tokens</strong></p>
+      </div>
+      <div class="eco-card coming">
+        <div class="eco-logo">🧠</div>
+        <h4>TurboQuant</h4>
+        <p>Google KV compression<br><strong>6x less memory</strong></p>
+      </div>
+      <div class="eco-card coming">
         <div class="eco-logo">🐾</div>
         <h4>DefenseClaw</h4>
-        <p>Cisco supply chain security<br>Skills + MCP scanning</p>
+        <p>Cisco supply chain<br><strong>Scans the skills</strong></p>
       </div>
-      <div class="eco-card eco-coming">
-        <div class="eco-logo">🧠</div>
+      <div class="eco-card coming">
+        <div class="eco-logo">🔒</div>
+        <h4>OpenShell</h4>
+        <p>NVIDIA kernel sandbox<br><strong>Isolates the process</strong></p>
+      </div>
+      <div class="eco-card coming">
+        <div class="eco-logo">🤖</div>
         <h4>DeepAgents</h4>
-        <p>Multi-step planning<br>Autonomous decomposition</p>
-      </div>
-      <div class="eco-card eco-coming">
-        <div class="eco-logo">⌨️</div>
-        <h4>OpenCode</h4>
-        <p>Interactive coding agent<br>Tool use + governance</p>
+        <p>Multi-step planning<br><strong>Thinks for the agents</strong></p>
       </div>
     </div>
+
     <p class="teaser-text">
-      The agentic AI security stack is forming.<br>
-      <strong>DefenseClaw</strong> scans. <strong>OpenShell</strong> sandboxes. <strong>AgentGuard</strong> governs.<br>
-      <strong>ShellForge</strong> runs them all — locally, on your machine.<br><br>
-      <em>Integration coming Q3 2026. Star the repo to follow along.</em>
+      <strong>RTK</strong> compresses the input. <strong>TurboQuant</strong> compresses the memory.<br>
+      <strong>Ollama</strong> runs the model. <strong>ShellForge</strong> runs the agent.<br>
+      <strong>AgentGuard</strong> governs. <strong>DefenseClaw</strong> scans. <strong>OpenShell</strong> sandboxes.<br><br>
+      All open source. All local. All on your Mac.<br><br>
+      <em>Integrations landing throughout 2026. <a href="https://github.com/AgentGuardHQ/shellforge">Star the repo</a> to follow along.</em>
     </p>
   </div>
 </section>


### PR DESCRIPTION
Updates the ecosystem section of the GitHub Pages landing page:

- **Stack diagram**: visual flow from Prompt → RTK → TurboQuant → Ollama → ShellForge → AgentGuard → DefenseClaw → OpenShell
- **8 ecosystem cards**: ShellForge, AgentGuard, Ollama, RTK, TurboQuant, DefenseClaw, OpenShell, DeepAgents
- **Narrative**: RTK compresses input, TurboQuant compresses memory, Ollama runs model, ShellForge runs agent, AgentGuard governs, DefenseClaw scans, OpenShell sandboxes

All open source. All local. All on your Mac.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>