### PR TITLE
fix: ListModels returns empty on network error, reduce MaxOutput to 2000 (closes #5, closes #7)

### DIFF
--- a/internal/ollama/client.go
+++ b/internal/ollama/client.go
@@ -144,7 +144,8 @@ func ListModels() ([]string, error) {
 client := &http.Client{Timeout: 5 * time.Second}
 resp, err := client.Get(Host + "/api/tags")
 if err != nil {
-return nil, err
+// Network/connection error — return empty list so callers stay safe.
+return []string{}, nil
 }
 defer resp.Body.Close()
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,7 +11,7 @@ import (
 "github.com/AgentGuardHQ/shellforge/internal/logger"
 )
 
-const MaxOutput = 8000
+const MaxOutput = 2000
 
 type Definition struct {
 Name        string


### PR DESCRIPTION
## Summary

- **Bug #5**: `ListModels()` in `internal/ollama/client.go` now returns `([]string{}, nil)` instead of `(nil, err)` when the HTTP request fails due to a network/connection error. This prevents callers from crashing when Ollama is unreachable — they simply get an empty model list. Valid HTTP error responses (e.g. 401) still propagate as before.
- **Bug #7**: Reduced `MaxOutput` constant in `internal/tools/tools.go` from 8000 to 2000 chars. With 5 tool calls, the previous limit could produce 40,000 chars of aggregate output, blowing past small Ollama context windows (4096 tokens). At 2000 chars per file, the aggregate stays within budget for the default context size.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (no test files in affected packages)
- [ ] Manual: confirm `ListModels()` returns empty list when Ollama is stopped
- [ ] Manual: confirm qa-agent stays within context window with 5-file reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)