### PR TITLE
feat: goreleaser + Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,51 +3,26 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: darwin
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
-      - name: Build
+          go-version: "1.21"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
         env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-        run: |
-          go build -ldflags="-s -w -X main.version=${{ github.ref_name }}" \
-            -o shellforge-${{ matrix.goos }}-${{ matrix.goarch }} \
-            ./cmd/shellforge/
-      - uses: actions/upload-artifact@v4
-        with:
-          name: shellforge-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: shellforge-${{ matrix.goos }}-${{ matrix.goarch }}
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            shellforge-*/shellforge-*
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Go binary
-shellforge
+# Go binary (root only — don't ignore cmd/shellforge/)
+/shellforge
 *.exe
 
 # Build artifacts

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+version: 2
+project_name: shellforge
+
+builds:
+  - main: ./cmd/shellforge/
+    binary: shellforge
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+
+brews:
+  - repository:
+      owner: AgentGuardHQ
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/AgentGuardHQ/shellforge"
+    description: "Local governed agent runtime — wraps Ollama + AgentGuard governance"
+    license: "MIT"
+    install: |
+      bin.install "shellforge"
+    test: |
+      system "#{bin}/shellforge", "version"

--- a/cmd/shellforge/main.go
+++ b/cmd/shellforge/main.go
@@ -1,0 +1,287 @@
+// ShellForge — local governed agent runtime.
+// Single Go binary. Wraps Ollama + governance. Full ecosystem integration.
+package main
+
+import (
+"fmt"
+"os"
+"os/exec"
+"path/filepath"
+"runtime"
+"strings"
+"time"
+
+"github.com/AgentGuardHQ/shellforge/internal/agent"
+"github.com/AgentGuardHQ/shellforge/internal/governance"
+"github.com/AgentGuardHQ/shellforge/internal/logger"
+"github.com/AgentGuardHQ/shellforge/internal/ollama"
+)
+
+var version = "0.2.0"
+
+func main() {
+if len(os.Args) < 2 {
+printUsage()
+os.Exit(1)
+}
+
+switch os.Args[1] {
+case "setup":
+cmdSetup()
+case "qa":
+target := "."
+if len(os.Args) > 2 {
+target = os.Args[2]
+}
+cmdQA(target)
+case "report":
+repo := "."
+if len(os.Args) > 2 {
+repo = os.Args[2]
+}
+cmdReport(repo)
+case "agent":
+if len(os.Args) < 3 {
+fmt.Fprintln(os.Stderr, "Usage: shellforge agent \"your prompt\"")
+os.Exit(1)
+}
+cmdAgent(strings.Join(os.Args[2:], " "))
+case "status":
+cmdStatusFull()
+case "scan":
+cmdScan()
+case "version", "--version", "-v":
+fmt.Printf("shellforge %s (%s/%s)\n", version, runtime.GOOS, runtime.GOARCH)
+case "help", "--help", "-h":
+printUsage()
+default:
+fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
+printUsage()
+os.Exit(1)
+}
+}
+
+func printUsage() {
+fmt.Printf(`ShellForge %s — local governed agent runtime
+
+Usage:
+  shellforge setup                 Install Ollama, pull model, verify stack
+  shellforge qa [target]           QA analysis with tool use + governance
+  shellforge report [repo]         Weekly status report from git + logs
+  shellforge agent "prompt"        Run any task with agentic tool use
+  shellforge status                Full ecosystem health check
+  shellforge scan [dir]            DefenseClaw supply chain scan
+  shellforge version               Print version
+
+Governance:  agentguard.yaml — every tool call evaluated before execution.
+Engines:     native | opencode | deepagents
+Stack:       RTK · TurboQuant · Ollama · AgentGuard · OpenShell · DefenseClaw
+
+`, version)
+}
+
+func cmdSetup() {
+fmt.Println("=== ShellForge Setup ===")
+fmt.Printf("✓ Go %s\n", runtime.Version())
+
+if _, err := exec.LookPath("ollama"); err != nil {
+fmt.Println("→ Installing Ollama...")
+if runtime.GOOS == "darwin" {
+run("brew", "install", "ollama")
+} else {
+run("sh", "-c", "curl -fsSL https://ollama.ai/install.sh | sh")
+}
+} else {
+fmt.Println("✓ Ollama installed")
+}
+
+if !ollama.IsRunning() {
+fmt.Println("→ Starting Ollama...")
+cmd := exec.Command("ollama", "serve")
+cmd.Start()
+time.Sleep(3 * time.Second)
+}
+if ollama.IsRunning() {
+fmt.Println("✓ Ollama running")
+} else {
+fmt.Println("⚠ Ollama not responding — start manually: ollama serve")
+}
+
+model := ollama.Model
+fmt.Printf("→ Pulling model %s...\n", model)
+run("ollama", "pull", model)
+fmt.Printf("✓ Model ready: %s\n", model)
+
+configPath := findGovernanceConfig()
+if configPath != "" {
+eng, err := governance.NewEngine(configPath)
+if err != nil {
+fmt.Printf("⚠ Governance config error: %s\n", err)
+} else {
+fmt.Printf("✓ Governance: mode=%s, %d policies\n", eng.Mode, len(eng.Policies))
+}
+} else {
+fmt.Println("⚠ No agentguard.yaml found")
+}
+
+os.MkdirAll("outputs/logs", 0o755)
+os.MkdirAll("outputs/reports", 0o755)
+fmt.Println("✓ Output directories ready")
+fmt.Println("=== ShellForge Setup Complete ===")
+}
+
+func cmdQA(target string) {
+engine := mustGovernance()
+mustOllama()
+
+result, err := agent.RunLoop(agent.LoopConfig{
+Agent:       "qa-agent",
+System:      "You are a QA engineer. Analyze source code and suggest specific, actionable test cases. Use tools to read files and run type checks. Be thorough but concise.",
+UserPrompt:  fmt.Sprintf("Analyze the source code in %q for test gaps and quality issues. Use list_files to find source files, read_file to examine them, and run_shell to run any available linters. Produce a structured report.", target),
+Model:       ollama.Model,
+MaxTurns:    10,
+TimeoutMs:   120_000,
+OutputDir:   "outputs/logs",
+TokenBudget: 3000,
+}, engine)
+if err != nil {
+logger.Error("qa-agent", err.Error())
+os.Exit(1)
+}
+printResult("qa-agent", result)
+saveReport("outputs/logs", "qa", result)
+}
+
+func cmdReport(repo string) {
+engine := mustGovernance()
+mustOllama()
+
+result, err := agent.RunLoop(agent.LoopConfig{
+Agent:       "report-agent",
+System:      "You are a technical writer. Generate concise markdown status reports. Use tools to gather data.",
+UserPrompt:  fmt.Sprintf("Generate a weekly status report for %q. Use run_shell for git log, list_files + read_file for agent logs in outputs/. Output markdown with Summary, Changes, Recommendations.", repo),
+Model:       ollama.Model,
+MaxTurns:    8,
+TimeoutMs:   90_000,
+OutputDir:   "outputs/reports",
+TokenBudget: 3000,
+}, engine)
+if err != nil {
+logger.Error("report-agent", err.Error())
+os.Exit(1)
+}
+printResult("report-agent", result)
+saveReport("outputs/reports", "report", result)
+}
+
+func cmdAgent(prompt string) {
+engine := mustGovernance()
+mustOllama()
+
+result, err := agent.RunLoop(agent.LoopConfig{
+Agent:       "prototype-agent",
+System:      "You are a senior engineer. Complete the requested task using available tools. Read files, write files, run commands, search code. Be precise.",
+UserPrompt:  prompt,
+Model:       ollama.Model,
+MaxTurns:    15,
+TimeoutMs:   180_000,
+OutputDir:   "outputs/logs",
+TokenBudget: 3000,
+}, engine)
+if err != nil {
+logger.Error("prototype-agent", err.Error())
+os.Exit(1)
+}
+printResult("prototype-agent", result)
+saveReport("outputs/logs", "prototype", result)
+}
+
+func cmdScan() {
+fmt.Println("[🐾 DefenseClaw] Scanning agent skills and plugins...")
+dir := "."
+if len(os.Args) > 2 {
+dir = os.Args[2]
+}
+// Use defenseclaw if available, otherwise do a basic scan
+if _, err := exec.LookPath("defenseclaw"); err == nil {
+cmd := exec.Command("defenseclaw", "scan", "--dir", dir)
+cmd.Stdout = os.Stdout
+cmd.Stderr = os.Stderr
+cmd.Run()
+} else {
+fmt.Println("  DefenseClaw not installed — running basic integrity check")
+fmt.Printf("  Scanning %s for agent configs...\n", dir)
+// Basic: check for agentguard.yaml, list agent files
+if _, err := os.Stat("agentguard.yaml"); err == nil {
+fmt.Println("  ✓ agentguard.yaml found")
+}
+entries, _ := filepath.Glob(filepath.Join(dir, "agents", "*.ts"))
+goEntries, _ := filepath.Glob(filepath.Join(dir, "internal", "**", "*.go"))
+fmt.Printf("  Found %d TS agents, %d Go files\n", len(entries), len(goEntries))
+fmt.Println("  Install defenseclaw for full supply chain scanning")
+}
+}
+
+// ── Helpers ──
+
+func mustGovernance() *governance.Engine {
+configPath := findGovernanceConfig()
+if configPath == "" {
+fmt.Fprintln(os.Stderr, "ERROR: agentguard.yaml not found")
+os.Exit(1)
+}
+eng, err := governance.NewEngine(configPath)
+if err != nil {
+fmt.Fprintf(os.Stderr, "ERROR: governance config: %s\n", err)
+os.Exit(1)
+}
+fmt.Printf("[🛡️ AgentGuard] governance loaded — mode: %s, %d policies\n", eng.Mode, len(eng.Policies))
+return eng
+}
+
+func mustOllama() {
+if !ollama.IsRunning() {
+fmt.Fprintln(os.Stderr, "ERROR: Ollama not running. Start: ollama serve")
+os.Exit(1)
+}
+}
+
+func findGovernanceConfig() string {
+for _, c := range []string{"agentguard.yaml", filepath.Join("..", "agentguard.yaml")} {
+if _, err := os.Stat(c); err == nil {
+return c
+}
+}
+return ""
+}
+
+func printResult(name string, r *agent.RunResult) {
+fmt.Println()
+status := "✓ success"
+if !r.Success {
+status = "✗ failed"
+}
+fmt.Printf("[%s] %s — %d turns, %d tool calls, %d denials\n", name, status, r.Turns, r.ToolCalls, r.Denials)
+fmt.Printf("  tokens: %d prompt + %d response | %dms\n", r.PromptTok, r.ResponseTok, r.DurationMs)
+if r.Output != "" {
+fmt.Println()
+fmt.Println(r.Output)
+}
+}
+
+func saveReport(dir, prefix string, r *agent.RunResult) {
+os.MkdirAll(dir, 0o755)
+ts := time.Now().Format("2006-01-02T15-04-05")
+path := filepath.Join(dir, fmt.Sprintf("%s-%s.md", prefix, ts))
+content := fmt.Sprintf("# %s — %s\n\n**Turns:** %d | **Tool calls:** %d | **Denials:** %d\n**Tokens:** %d+%d | **Duration:** %dms\n\n%s\n",
+prefix, time.Now().Format(time.RFC3339), r.Turns, r.ToolCalls, r.Denials, r.PromptTok, r.ResponseTok, r.DurationMs, r.Output)
+os.WriteFile(path, []byte(content), 0o644)
+fmt.Printf("\n→ Saved to %s\n", path)
+}
+
+func run(name string, args ...string) {
+cmd := exec.Command(name, args...)
+cmd.Stdout = os.Stdout
+cmd.Stderr = os.Stderr
+cmd.Run()
+}

--- a/cmd/shellforge/status.go
+++ b/cmd/shellforge/status.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+"fmt"
+"os/exec"
+"strings"
+
+"github.com/AgentGuardHQ/shellforge/internal/governance"
+"github.com/AgentGuardHQ/shellforge/internal/integration"
+"github.com/AgentGuardHQ/shellforge/internal/ollama"
+)
+
+func cmdStatusFull() {
+fmt.Printf("ShellForge %s — Full Ecosystem Status\n", version)
+fmt.Println(strings.Repeat("─", 50))
+
+// ── Model Layer ──
+fmt.Println("\n🦙 Model Layer")
+if ollama.IsRunning() {
+models, _ := ollama.ListModels()
+fmt.Printf("  ✓ Ollama: running (%d models)\n", len(models))
+for _, m := range models {
+tag := ""
+if m == ollama.Model {
+tag = " ← active"
+}
+fmt.Printf("    • %s%s\n", m, tag)
+}
+} else {
+fmt.Println("  ✗ Ollama: not running (start: ollama serve)")
+}
+
+// ── Token Compression ──
+fmt.Println("\n⚡ Token Compression")
+rtk := integration.NewRTK()
+if rtk.Available() {
+fmt.Printf("  ✓ RTK: %s (60-90%% token savings on shell output)\n", rtk.Version())
+} else {
+fmt.Println("  ○ RTK: not installed (brew install rtk-ai/tap/rtk)")
+}
+
+// ── Memory Optimization ──
+fmt.Println("\n🧠 Memory Optimization")
+tq := integration.NewTurboQuant()
+if tq.Available() {
+fmt.Println("  ✓ TurboQuant: installed (3-bit KV cache, 6x compression)")
+est := tq.EstimateMemory(1.7, 4096)
+fmt.Printf("    qwen3:1.7b → %.1fGB standard, %.1fGB with TQ (%.0f%% savings)\n",
+est.TotalStandard, est.TotalTQ, est.SavingsPercent)
+} else {
+fmt.Println("  ○ TurboQuant: not installed (pip install turboquant-pytorch)")
+}
+
+// ── Governance ──
+fmt.Println("\n🛡️  Governance")
+configPath := findGovernanceConfig()
+if configPath != "" {
+eng, err := governance.NewEngine(configPath)
+if err != nil {
+fmt.Printf("  ✗ Policy: %s\n", err)
+} else {
+fmt.Printf("  ✓ Policy: mode=%s, %d rules (%s)\n", eng.Mode, len(eng.Policies), configPath)
+for _, p := range eng.Policies {
+fmt.Printf("    • %s [%s] %s\n", p.Name, p.Action, p.Description)
+}
+}
+} else {
+fmt.Println("  ✗ Policy: no agentguard.yaml found")
+}
+
+agk := integration.NewAgentGuardKernel()
+if agk.Available() {
+fmt.Printf("  ✓ Kernel: %s (full evaluation — blast radius, personas, invariants)\n", agk.Version())
+} else {
+fmt.Println("  ○ Kernel: built-in YAML evaluator (install kernel for full evaluation)")
+}
+
+// ── Agent Engines ──
+fmt.Println("\n🤖 Agent Engines")
+fmt.Println("  ✓ native: built-in Ollama loop with tool use")
+if _, err := exec.LookPath("opencode"); err == nil {
+fmt.Println("  ✓ opencode: detected (Go-native AI coding agent)")
+} else {
+fmt.Println("  ○ opencode: not installed (npm i -g opencode-ai)")
+}
+checkNodeModule("deepagents", "deepagents", "multi-step planning via LangGraph")
+
+// ── Security ──
+fmt.Println("\n🔒 Security")
+openshell := integration.NewOpenShell()
+if openshell.Available() {
+fmt.Println("  ✓ OpenShell: NVIDIA kernel sandbox (Landlock + Seccomp)")
+} else {
+fmt.Println("  ○ OpenShell: not installed (https://github.com/NVIDIA/OpenShell)")
+}
+
+dc := integration.NewDefenseClaw()
+if dc.Available() {
+fmt.Println("  ✓ DefenseClaw: Cisco supply chain scanner")
+} else {
+fmt.Println("  ○ DefenseClaw: not installed (https://github.com/cisco/defenseclaw)")
+}
+
+// ── Summary ──
+fmt.Println("\n" + strings.Repeat("─", 50))
+available := countAvailable(rtk.Available(), tq.Available(), agk.Available(),
+openshell.Available(), dc.Available())
+fmt.Printf("Stack: %d/8 integrations active\n", 2+available)
+}
+
+func checkNodeModule(pkg, name, desc string) {
+cmd := exec.Command("node", "-e", fmt.Sprintf("require('%s')", pkg))
+if cmd.Run() == nil {
+fmt.Printf("  ✓ %s: installed (%s)\n", name, desc)
+} else {
+fmt.Printf("  ○ %s: not installed (npm i %s)\n", name, pkg)
+}
+}
+
+func countAvailable(flags ...bool) int {
+n := 0
+for _, f := range flags {
+if f {
+n++
+}
+}
+return n
+}


### PR DESCRIPTION
## Summary
- **Fix critical .gitignore bug**: `shellforge` pattern was ignoring `cmd/shellforge/` source directory — release workflow would have failed
- **Add `cmd/shellforge/` to git**: entrypoint was never committed (gitignored)
- **Replace manual matrix build with goreleaser**: cross-compile, checksums, changelog
- **Add Homebrew formula auto-publish**: pushes formula to `AgentGuardHQ/homebrew-tap` on tag

## Setup required before first release
1. Create repo: `AgentGuardHQ/homebrew-tap`
2. Create a PAT with `repo` scope and add as `HOMEBREW_TAP_TOKEN` secret in shellforge repo settings
3. Tag and push: `git tag v0.2.0 && git push --tags`

## After release
```bash
brew tap AgentGuardHQ/tap
brew install shellforge
```

## Test plan
- [ ] Verify `go build ./cmd/shellforge/` passes in CI
- [ ] Merge, create `homebrew-tap` repo, add secret
- [ ] Tag `v0.2.0`, verify goreleaser produces darwin-arm64/amd64 + linux binaries
- [ ] `brew tap AgentGuardHQ/tap && brew install shellforge` on Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)