### PR TITLE
docs: Homebrew install as primary method + site update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,29 @@
 
 ## Quick Start
 
+### Install via Homebrew (macOS / Linux)
+
 ```bash
-# 1. Clone
+brew tap AgentGuardHQ/tap
+brew install shellforge
+
+shellforge setup                 # pulls Ollama + model + verifies stack
+shellforge status                # verify 8/8 integrations ✓
+shellforge qa                    # run the QA agent
+```
+
+### Install from source
+
+```bash
 git clone https://github.com/AgentGuardHQ/shellforge.git
 cd shellforge
 
-# 2. Install ecosystem (interactive — pick your layers)
-bash scripts/setup.sh --all      # everything
-# OR  bash scripts/setup.sh           # interactive picker
-# OR  bash scripts/setup.sh --minimal # core only (Go + Ollama)
-
-# 3. Build & run
+bash scripts/setup.sh --all     # install full 8-layer ecosystem
 go build -o shellforge ./cmd/shellforge/
-./shellforge status              # verify 8/8 integrations ✓
-./shellforge qa                  # run the QA agent
+./shellforge status
 ```
 
-**Requirements:** macOS (Apple Silicon) or Linux · Go 1.18+ · ~1.3 GB RAM (1.7B model)
+**Requirements:** macOS (Apple Silicon/Intel) or Linux · ~1.3 GB RAM (1.7B model)
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -427,7 +427,9 @@
         <div class="terminal-dot g"></div>
       </div>
       <div class="terminal-code">
-        <span class="prompt">$</span> <span class="cmd">bash scripts/setup.sh</span><br>
+        <span class="prompt">$</span> <span class="cmd">brew tap AgentGuardHQ/tap</span><br>
+        <span class="prompt">$</span> <span class="cmd">brew install shellforge</span><br>
+        <span class="prompt">$</span> <span class="cmd">shellforge setup</span><br>
         <span class="output">=== ShellForge Setup ===</span><br>
         <span class="output">✓ Go 1.23 installed</span><br>
         <span class="output">✓ Ollama running</span><br>
@@ -720,12 +722,12 @@
 <section class="cta" id="quickstart">
   <div class="container">
     <h2>Get Started in 60 Seconds</h2>
-    <p>Clone. Setup. Forge.</p>
+    <p>Install. Setup. Forge.</p>
     <div class="cta-code" style="text-align: left; line-height: 2;">
-      <span class="prompt">$</span> git clone https://github.com/AgentGuardHQ/shellforge<br>
-      <span class="prompt">$</span> cd shellforge<br>
-      <span class="prompt">$</span> bash scripts/setup.sh --all<br>
-      <span class="prompt">$</span> ./shellforge status
+      <span class="prompt">$</span> brew tap AgentGuardHQ/tap<br>
+      <span class="prompt">$</span> brew install shellforge<br>
+      <span class="prompt">$</span> shellforge setup<br>
+      <span class="prompt">$</span> shellforge status
     </div>
     <br><br>
     <div class="hero-actions">


### PR DESCRIPTION
## Summary
- README: `brew tap AgentGuardHQ/tap && brew install shellforge` as primary Quick Start
- Site hero terminal: shows brew install flow instead of git clone
- Site CTA section: updated to brew commands

## Test plan
- [ ] Verify site renders at agentguardhq.github.io/shellforge after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)