### PR TITLE
feat: normalizer + correction engine wired into agent loop

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -13,11 +13,13 @@ import (
 "encoding/json"
 "fmt"
 "regexp"
-"strings"
 "time"
 
+"github.com/AgentGuardHQ/shellforge/internal/action"
+"github.com/AgentGuardHQ/shellforge/internal/correction"
 "github.com/AgentGuardHQ/shellforge/internal/governance"
 "github.com/AgentGuardHQ/shellforge/internal/logger"
+"github.com/AgentGuardHQ/shellforge/internal/normalizer"
 "github.com/AgentGuardHQ/shellforge/internal/ollama"
 "github.com/AgentGuardHQ/shellforge/internal/tools"
 )
@@ -56,6 +58,11 @@ start := time.Now()
 logger.Init(cfg.OutputDir, cfg.Agent)
 defer logger.Close()
 
+// Orchestrator integration: generate run identity and correction engine.
+runID := fmt.Sprintf("run_%d", time.Now().UnixMilli())
+var seq int
+corrector := correction.NewEngine(3, 10) // 3 retries per action, 10 total budget
+
 systemPrompt := buildSystemPrompt(cfg.System)
 messages := []ollama.ChatMessage{
 {Role: "system", Content: systemPrompt},
@@ -65,7 +72,7 @@ messages := []ollama.ChatMessage{
 result := &RunResult{}
 var log []string
 
-logger.Agent(cfg.Agent, fmt.Sprintf("starting — max %d turns, model: %s", cfg.MaxTurns, cfg.Model))
+logger.Agent(cfg.Agent, fmt.Sprintf("starting — max %d turns, model: %s, run: %s", cfg.MaxTurns, cfg.Model, runID))
 
 for turn := 1; turn <= cfg.MaxTurns; turn++ {
 elapsed := time.Since(start).Milliseconds()
@@ -104,11 +111,71 @@ break
 }
 
 result.ToolCalls++
-toolResult := tools.Execute(engine, cfg.Agent, toolCall.Tool, toolCall.Params)
+seq++
 
-if !toolResult.Success && strings.HasPrefix(toolResult.Output, "DENIED") {
-result.Denials++
+// ── Normalizer: convert raw tool call to Canonical Action Representation ──
+proposal := normalizer.Normalize(runID, seq, cfg.Agent, toolCall.Tool, toolCall.Params)
+fp := normalizer.Fingerprint(proposal)
+
+// ── Correction engine: check if this action should be retried or skipped ──
+canAttempt, skipReason := corrector.ShouldCorrect(fp)
+if !canAttempt {
+// Too many retries or in lockdown — skip this action entirely.
+logger.Agent(cfg.Agent, fmt.Sprintf("action skipped: %s", skipReason))
+messages = append(messages, ollama.ChatMessage{
+Role:    "user",
+Content: fmt.Sprintf("Tool %q was skipped: %s. Try a different approach.", toolCall.Tool, skipReason),
+})
+summary := fmt.Sprintf("[turn %d] %s → skipped (%s)", turn, toolCall.Tool, skipReason)
+log = append(log, summary)
+continue
 }
+
+// ── Governance evaluation (existing) ──
+decision := engine.Evaluate(toolCall.Tool, toolCall.Params)
+
+if !decision.Allowed {
+result.Denials++
+
+// Map governance.Decision to action.GovernanceDecision for the correction engine.
+govDecision := action.GovernanceDecision{
+Allowed:  false,
+Decision: "deny",
+Reason:   decision.Reason,
+Rule:     decision.PolicyName,
+}
+
+// Record denial and attempt correction.
+corrector.RecordDenial(fp, govDecision)
+logger.Governance(cfg.Agent, toolCall.Tool, toolCall.Params, decision.Allowed, decision.PolicyName, decision.Reason)
+
+canCorrect, _ := corrector.ShouldCorrect(fp)
+if canCorrect {
+// Build corrective feedback and feed it back to the LLM.
+feedback := corrector.BuildFeedback(proposal, govDecision)
+logger.Agent(cfg.Agent, fmt.Sprintf("governance denied %q — sending correction feedback (escalation: %s)", toolCall.Tool, corrector.Level()))
+messages = append(messages, ollama.ChatMessage{
+Role:    "user",
+Content: feedback,
+})
+} else {
+// Exhausted retries — skip and inform the LLM.
+logger.Agent(cfg.Agent, fmt.Sprintf("governance denied %q — no retries left, skipping", toolCall.Tool))
+messages = append(messages, ollama.ChatMessage{
+Role:    "user",
+Content: fmt.Sprintf("Tool %q was denied and cannot be retried. Move on to a different approach.", toolCall.Tool),
+})
+}
+
+summary := fmt.Sprintf("[turn %d] %s → denied (%s)", turn, toolCall.Tool, decision.PolicyName)
+log = append(log, summary)
+continue
+}
+
+// ── Governance allowed: log and execute tool ──
+logger.Governance(cfg.Agent, toolCall.Tool, toolCall.Params, decision.Allowed, decision.PolicyName, decision.Reason)
+toolResult := tools.ExecuteDirect(toolCall.Tool, toolCall.Params, engine.GetTimeout())
+logger.ToolResult(cfg.Agent, toolCall.Tool, toolResult.Success, toolResult.Output)
 
 var msg string
 if toolResult.Success {
@@ -196,7 +263,7 @@ Available tools:
 ## Rules
 - Use ONE tool per response. Wait for the result before calling another.
 - When done, respond normally WITHOUT a tool call — that is your final answer.
-- If governance denies a tool call, do NOT retry it.
+- If governance denies a tool call, do NOT retry the same action — try an alternative.
 - Keep tool usage focused and minimal.`
 }
 

--- a/internal/correction/engine.go
+++ b/internal/correction/engine.go
@@ -1,0 +1,132 @@
+// Package correction handles governance denials by tracking repeated
+// offenses, escalating enforcement, and generating corrective feedback
+// that guides the LLM toward compliant alternatives.
+package correction
+
+import (
+	"fmt"
+
+	"github.com/AgentGuardHQ/shellforge/internal/action"
+)
+
+// EscalationLevel tracks how aggressively the correction engine restricts
+// the agent based on cumulative denial count.
+type EscalationLevel int
+
+const (
+	Normal   EscalationLevel = iota // < 3 denials
+	Elevated                        // 3-6
+	High                            // 7-9
+	Lockdown                        // >= 10
+)
+
+// String returns a human-readable label for the escalation level.
+func (e EscalationLevel) String() string {
+	switch e {
+	case Normal:
+		return "normal"
+	case Elevated:
+		return "elevated"
+	case High:
+		return "high"
+	case Lockdown:
+		return "lockdown"
+	default:
+		return "unknown"
+	}
+}
+
+// Engine handles governance denials by generating corrective feedback.
+type Engine struct {
+	maxRetries   int
+	totalDenials int
+	maxTotal     int
+	seen         map[string]int // fingerprint -> denial count
+	escalation   EscalationLevel
+}
+
+// NewEngine creates a correction engine with the given per-action retry
+// limit and total denial budget.
+func NewEngine(maxRetries, maxTotal int) *Engine {
+	return &Engine{
+		maxRetries: maxRetries,
+		maxTotal:   maxTotal,
+		seen:       make(map[string]int),
+		escalation: Normal,
+	}
+}
+
+// ShouldCorrect checks if correction is possible or if we should skip/abort.
+// Returns (true, "") if the agent may retry, or (false, reason) if it must stop.
+func (e *Engine) ShouldCorrect(fingerprint string) (bool, string) {
+	if e.escalation >= Lockdown {
+		return false, "agent is in lockdown — too many governance denials"
+	}
+
+	count := e.seen[fingerprint]
+	if count >= e.maxRetries {
+		return false, fmt.Sprintf("action retried %d times (max %d) — skipping", count, e.maxRetries)
+	}
+
+	if e.totalDenials >= e.maxTotal {
+		return false, fmt.Sprintf("total denial budget exhausted (%d/%d)", e.totalDenials, e.maxTotal)
+	}
+
+	return true, ""
+}
+
+// RecordDenial tracks a denial and updates escalation state.
+func (e *Engine) RecordDenial(fingerprint string, denial action.GovernanceDecision) {
+	e.seen[fingerprint]++
+	e.totalDenials++
+	e.updateEscalation()
+}
+
+// BuildFeedback creates a structured prompt for the LLM to correct its action.
+func (e *Engine) BuildFeedback(proposal action.Proposal, denial action.GovernanceDecision) string {
+	feedback := fmt.Sprintf(
+		"Your action was denied by governance policy.\n"+
+			"Action: %s → %s\n"+
+			"Reason: %s\n",
+		string(proposal.Type), proposal.Target, denial.Reason)
+
+	if denial.Suggestion != "" {
+		feedback += fmt.Sprintf("Suggestion: %s\n", denial.Suggestion)
+	}
+
+	if denial.Rule != "" {
+		feedback += fmt.Sprintf("Policy: %s\n", denial.Rule)
+	}
+
+	feedback += "\nProduce a different action that achieves the same goal while complying with governance. Do NOT repeat the denied action."
+
+	if e.escalation >= Elevated {
+		feedback += fmt.Sprintf("\n\nWARNING: Escalation level is %s (%d total denials). Further violations may cause the agent to be locked out.", e.escalation, e.totalDenials)
+	}
+
+	return feedback
+}
+
+// Level returns the current escalation level.
+func (e *Engine) Level() EscalationLevel {
+	return e.escalation
+}
+
+// TotalDenials returns the cumulative denial count.
+func (e *Engine) TotalDenials() int {
+	return e.totalDenials
+}
+
+// updateEscalation recalculates the escalation level from totalDenials.
+func (e *Engine) updateEscalation() {
+	switch {
+	case e.totalDenials >= 10:
+		e.escalation = Lockdown
+	case e.totalDenials >= 7:
+		e.escalation = High
+	case e.totalDenials >= 3:
+		e.escalation = Elevated
+	default:
+		e.escalation = Normal
+	}
+}

--- a/internal/normalizer/normalizer.go
+++ b/internal/normalizer/normalizer.go
@@ -1,0 +1,136 @@
+// Package normalizer converts raw tool calls into Canonical Action
+// Representations (CARs). This is the bridge between the agent loop's
+// free-form tool calls and the structured governance/orchestrator layer.
+package normalizer
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/AgentGuardHQ/shellforge/internal/action"
+)
+
+// readOnlyCommands are shell commands that only inspect state.
+var readOnlyCommands = []string{
+	"ls", "cat", "head", "tail", "grep", "find", "echo",
+	"pwd", "which", "go test", "go vet",
+}
+
+// destructiveCommands are shell commands with high blast radius.
+var destructiveCommands = []string{
+	"rm", "git push", "git reset", "chmod", "chown", "kill", "dd",
+}
+
+// Normalize converts a raw tool call into a Canonical Action Representation.
+func Normalize(runID string, sequence int, agent string, toolName string, params map[string]string) action.Proposal {
+	actionType, risk, scope := classifyTool(toolName, params)
+	target := extractTarget(toolName, params)
+
+	// Convert params to map[string]any for the Proposal struct.
+	anyParams := make(map[string]any, len(params))
+	for k, v := range params {
+		anyParams[k] = v
+	}
+
+	return action.Proposal{
+		ID:       fmt.Sprintf("%s_%d", runID, sequence),
+		RunID:    runID,
+		Sequence: sequence,
+		Agent:    agent,
+		Type:     actionType,
+		Target:   target,
+		Params:   anyParams,
+		Risk:     risk,
+		Scope:    scope,
+	}
+}
+
+// Fingerprint produces a deterministic hash of (type + target + sorted params)
+// for anti-loop detection. Repeated identical proposals get the same fingerprint.
+func Fingerprint(p action.Proposal) string {
+	h := sha256.New()
+	h.Write([]byte(string(p.Type)))
+	h.Write([]byte("|"))
+	h.Write([]byte(p.Target))
+	h.Write([]byte("|"))
+
+	// Sort param keys for deterministic hashing.
+	keys := make([]string, 0, len(p.Params))
+	for k := range p.Params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte("="))
+		h.Write([]byte(fmt.Sprintf("%v", p.Params[k])))
+		h.Write([]byte(";"))
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil))[:16]
+}
+
+// classifyTool maps a tool name + params to (ActionType, RiskLevel, Scope).
+func classifyTool(toolName string, params map[string]string) (action.ActionType, action.RiskLevel, action.Scope) {
+	switch toolName {
+	case "read_file":
+		return action.FileRead, action.RiskReadOnly, action.ScopeFile
+
+	case "write_file":
+		return action.FileWrite, action.RiskMutating, action.ScopeFile
+
+	case "run_shell":
+		risk := classifyShellRisk(params["command"])
+		return action.ShellExec, risk, action.ScopeSystem
+
+	case "list_files":
+		return action.FileRead, action.RiskReadOnly, action.ScopeDirectory
+
+	case "search_files":
+		return action.FileRead, action.RiskReadOnly, action.ScopeDirectory
+
+	default:
+		// Unknown tools default to mutating for safety.
+		return action.ShellExec, action.RiskMutating, action.ScopeSystem
+	}
+}
+
+// classifyShellRisk inspects a shell command string to determine risk level.
+func classifyShellRisk(command string) action.RiskLevel {
+	trimmed := strings.TrimSpace(command)
+
+	// Check destructive patterns first (highest priority).
+	for _, pattern := range destructiveCommands {
+		if strings.Contains(trimmed, pattern) {
+			return action.RiskDestructive
+		}
+	}
+
+	// Check read-only patterns: command must START with one of these.
+	for _, prefix := range readOnlyCommands {
+		if strings.HasPrefix(trimmed, prefix) {
+			return action.RiskReadOnly
+		}
+	}
+
+	// Default: mutating.
+	return action.RiskMutating
+}
+
+// extractTarget pulls the most relevant target path/identifier from params.
+func extractTarget(toolName string, params map[string]string) string {
+	switch toolName {
+	case "read_file", "write_file":
+		return params["path"]
+	case "run_shell":
+		return params["command"]
+	case "list_files":
+		return params["directory"]
+	case "search_files":
+		return params["directory"]
+	default:
+		return ""
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -59,6 +59,14 @@ func NewRunState(runID, task string, maxRetries int) *RunState {
 	}
 }
 
+// NewRun creates a RunState with an auto-generated ID and default settings.
+// This is a convenience constructor for callers that do not need to control
+// the run ID or retry budget.
+func NewRun(task string) *RunState {
+	runID := fmt.Sprintf("run_%d", time.Now().UnixMilli())
+	return NewRunState(runID, task, 3)
+}
+
 // Transition moves the run to a new phase if the transition is valid.
 // Returns an error for invalid transitions, preventing illegal state changes.
 func (s *RunState) Transition(to Phase) error {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -69,6 +69,16 @@ Params: []Param{
 },
 }
 
+// ExecuteDirect runs a tool implementation without governance evaluation.
+// Use this when governance has already been checked by the caller (e.g., the agent loop).
+func ExecuteDirect(tool string, params map[string]string, timeoutSec int) Result {
+	impl, ok := impls[tool]
+	if !ok {
+		return Result{Success: false, Output: "Unknown tool: " + tool, Error: "unknown_tool"}
+	}
+	return impl(params, timeoutSec)
+}
+
 // Execute runs a tool call through governance, then executes if allowed.
 func Execute(engine *governance.Engine, agent, tool string, params map[string]string) Result {
 decision := engine.Evaluate(tool, params)


### PR DESCRIPTION
## Summary

- **Normalizer** (`internal/normalizer`): Converts raw tool calls into Canonical Action Representations (CARs). Maps tool names to action types, infers risk levels (read_only/mutating/destructive for shell commands), and produces deterministic fingerprints for anti-loop detection.
- **Correction Engine** (`internal/correction`): Tracks governance denials per-action and globally, escalates through Normal -> Elevated -> High -> Lockdown levels, and generates structured corrective feedback that guides the LLM toward compliant alternatives.
- **Agent Loop Integration** (`internal/agent/loop.go`): Every tool call now flows through normalize -> fingerprint -> correction check -> governance -> execute. Denied actions get corrective feedback injected as user messages instead of raw error strings. Repeated denials are tracked and eventually blocked.
- **ExecuteDirect** (`internal/tools/tools.go`): New function for callers that have already evaluated governance, avoiding double-evaluation.
- **NewRun** (`internal/orchestrator/state.go`): Convenience constructor with auto-generated RunID and default retry budget (not yet wired into the loop — that's Phase 7.2).

## Test plan

- [x] `go build ./cmd/shellforge/` compiles cleanly
- [x] `go vet ./...` passes with no warnings
- [x] `./shellforge version` runs correctly
- [ ] Smoke test: `./shellforge agent "list files in current directory"` (requires Ollama)
- [ ] Verify denial correction flow with a force-push tool call against enforce-mode governance

🤖 Generated with [Claude Code](https://claude.com/claude-code)