### PR TITLE
fix: release workflow — direct formula push instead of goreleaser brews

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,75 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+  update-homebrew:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION#v}"
+
+          # Download checksums
+          curl -sL "https://github.com/AgentGuardHQ/shellforge/releases/download/v${VERSION}/checksums.txt" -o checksums.txt
+
+          DARWIN_ARM64=$(grep darwin_arm64 checksums.txt | awk '{print $1}')
+          DARWIN_AMD64=$(grep darwin_amd64 checksums.txt | awk '{print $1}')
+          LINUX_ARM64=$(grep linux_arm64 checksums.txt | awk '{print $1}')
+          LINUX_AMD64=$(grep linux_amd64 checksums.txt | awk '{print $1}')
+
+          cat > shellforge.rb << FORMULA
+          # typed: false
+          # frozen_string_literal: true
+
+          class Shellforge < Formula
+            desc "Local governed agent runtime — wraps Ollama + AgentGuard governance"
+            homepage "https://github.com/AgentGuardHQ/shellforge"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/AgentGuardHQ/shellforge/releases/download/v${VERSION}/shellforge_${VERSION}_darwin_arm64.tar.gz"
+                sha256 "${DARWIN_ARM64}"
+              end
+              on_intel do
+                url "https://github.com/AgentGuardHQ/shellforge/releases/download/v${VERSION}/shellforge_${VERSION}_darwin_amd64.tar.gz"
+                sha256 "${DARWIN_AMD64}"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "https://github.com/AgentGuardHQ/shellforge/releases/download/v${VERSION}/shellforge_${VERSION}_linux_arm64.tar.gz"
+                sha256 "${LINUX_ARM64}"
+              end
+              on_intel do
+                url "https://github.com/AgentGuardHQ/shellforge/releases/download/v${VERSION}/shellforge_${VERSION}_linux_amd64.tar.gz"
+                sha256 "${LINUX_AMD64}"
+              end
+            end
+
+            def install
+              bin.install "shellforge"
+            end
+
+            test do
+              system "#{bin}/shellforge", "version"
+            end
+          end
+          FORMULA
+
+          # Push to homebrew-tap repo
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/AgentGuardHQ/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          cp shellforge.rb tap/Formula/shellforge.rb
+          cd tap
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add Formula/shellforge.rb
+          git commit -m "Update shellforge to ${VERSION}" || echo "No changes"
+          git push

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,17 +28,3 @@ changelog:
     exclude:
       - "^docs:"
       - "^chore:"
-
-brews:
-  - repository:
-      owner: AgentGuardHQ
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
-    homepage: "https://github.com/AgentGuardHQ/shellforge"
-    description: "Local governed agent runtime — wraps Ollama + AgentGuard governance"
-    license: "MIT"
-    install: |
-      bin.install "shellforge"
-    test: |
-      system "#{bin}/shellforge", "version"


### PR DESCRIPTION
Goreleaser's brews section requires a classic PAT. Fine-grained tokens cause
`net/http: invalid header field value for "Authorization"`. 

Fix: separate `update-homebrew` job that downloads checksums and pushes the
formula to homebrew-tap via git clone + commit + push. Works with any token type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)