### PR TITLE
fix: setup creates agentguard.yaml + clear Mac setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,52 @@
 
 ---
 
-## Quick Start
+## Quick Start (Mac)
 
-### Install via Homebrew (macOS / Linux)
+### 1. Install ShellForge
 
 ```bash
 brew tap AgentGuardHQ/tap
 brew install shellforge
-
-shellforge setup                 # pulls Ollama + model + verifies stack
-shellforge run crush "analyze this repo for test gaps"
 ```
 
-### Install from source
+Or from source: `git clone https://github.com/AgentGuardHQ/shellforge.git && cd shellforge && go build -o shellforge ./cmd/shellforge/`
+
+### 2. Install Ollama (if you haven't already)
 
 ```bash
-git clone https://github.com/AgentGuardHQ/shellforge.git
-cd shellforge
-go build -o shellforge ./cmd/shellforge/
-./shellforge setup
+brew install ollama
+ollama serve                     # start the model server (leave running)
 ```
 
-**Requirements:** macOS (Apple Silicon/Intel) or Linux · ~1.3 GB RAM (1.7B model)
+### 3. Pull a model
+
+```bash
+ollama pull qwen3:8b             # 8B — good balance (needs ~6GB RAM)
+# or: ollama pull qwen3:30b      # 30B — best quality (needs ~19GB, M4 Pro recommended)
+# or: ollama pull qwen3:1.7b     # 1.7B — fastest, minimal RAM
+```
+
+### 4. Run setup inside any repo
+
+```bash
+cd ~/your-project                # navigate to any repo you want to work in
+shellforge setup                 # creates agentguard.yaml + output dirs
+```
+
+This creates `agentguard.yaml` (governance policy) in your project root. Edit it to customize which actions are allowed/denied.
+
+### 5. Run an agent
+
+```bash
+shellforge agent "describe what this project does"
+shellforge agent "find test gaps and suggest improvements"
+shellforge agent "create a hello world program"
+```
+
+Every tool call (file reads, writes, shell commands) passes through governance before execution.
+
+**Requirements:** macOS (Apple Silicon or Intel) or Linux
 
 ---
 
@@ -89,12 +113,12 @@ shellforge status
 
 | Command | Description |
 |---------|-------------|
-| `shellforge run crush "prompt"` | Run Crush with full governance |
-| `shellforge serve agents.yaml` | Daemon mode — run scheduled agent swarm |
-| `shellforge agent "prompt"` | Run built-in agent with governance |
+| `shellforge setup` | Install Ollama, create governance config, verify stack |
+| `shellforge agent "prompt"` | Run a governed agent — every tool call checked |
+| `shellforge qa [dir]` | QA analysis — find test gaps and issues |
+| `shellforge report [repo]` | Generate a status report from git + logs |
+| `shellforge serve agents.yaml` | Daemon mode — run a 24/7 agent swarm |
 | `shellforge status` | Show ecosystem health |
-| `shellforge setup` | Install Ollama, pull model, verify stack |
-| `shellforge scan` | Run security scan via DefenseClaw |
 | `shellforge version` | Print version |
 
 ---

--- a/cmd/shellforge/main.go
+++ b/cmd/shellforge/main.go
@@ -81,9 +81,9 @@ Usage:
   shellforge version               Print version
 
   shellforge serve [config]       Daemon mode — run scheduled agent swarm
+
 Governance:  agentguard.yaml — every tool call evaluated before execution.
-Engines:     OpenCode · DeepAgents · Paperclip
-Stack:       RTK · TurboQuant · Ollama · AgentGuard · OpenShell · DefenseClaw
+Stack:       Ollama · AgentGuard · RTK
 
 `, version)
 }
@@ -121,6 +121,43 @@ run("ollama", "pull", model)
 fmt.Printf("✓ Model ready: %s\n", model)
 
 configPath := findGovernanceConfig()
+if configPath == "" {
+fmt.Println("→ Creating default agentguard.yaml...")
+defaultPolicy := `# agentguard.yaml — ShellForge governance policy
+# Mode: enforce (block violations) or monitor (log only)
+mode: enforce
+
+policies:
+  - name: no-force-push
+    description: Prevent force pushes to any remote
+    match:
+      command: "git push"
+      args_contain: ["--force", "-f", "--force-with-lease"]
+    action: deny
+    message: "Force push is not allowed by governance policy"
+
+  - name: no-destructive-rm
+    description: Block recursive force deletion
+    match:
+      command: "rm"
+      args_contain: ["-rf", "-fr"]
+    action: deny
+    message: "Recursive force deletion is not allowed"
+
+  - name: no-secret-access
+    description: Prevent reading sensitive files
+    match:
+      path_pattern: "*.env|*id_rsa|*id_ed25519|*.pem"
+    action: deny
+    message: "Access to secrets/keys is not allowed"
+`
+if err := os.WriteFile("agentguard.yaml", []byte(defaultPolicy), 0o644); err != nil {
+fmt.Printf("⚠ Could not create agentguard.yaml: %s\n", err)
+} else {
+configPath = "agentguard.yaml"
+fmt.Println("✓ Governance: agentguard.yaml created (enforce mode, 3 policies)")
+}
+}
 if configPath != "" {
 eng, err := governance.NewEngine(configPath)
 if err != nil {
@@ -128,14 +165,21 @@ fmt.Printf("⚠ Governance config error: %s\n", err)
 } else {
 fmt.Printf("✓ Governance: mode=%s, %d policies\n", eng.Mode, len(eng.Policies))
 }
+}
+
+// Check for optional tools
+if _, err := exec.LookPath("rtk"); err == nil {
+fmt.Println("✓ RTK installed (token compression)")
 } else {
-fmt.Println("⚠ No agentguard.yaml found")
+fmt.Println("  RTK not found (optional — install: npm i -g @anthropic/rtk)")
 }
 
 os.MkdirAll("outputs/logs", 0o755)
 os.MkdirAll("outputs/reports", 0o755)
 fmt.Println("✓ Output directories ready")
 fmt.Println("=== ShellForge Setup Complete ===")
+fmt.Println()
+fmt.Println("Next: shellforge agent \"describe what this project does\"")
 }
 
 func cmdQA(target string) {


### PR DESCRIPTION
- Setup now auto-creates agentguard.yaml (3 default policies)
- README rewritten with numbered Mac setup steps
- Cleaned up dead references in help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)