### PR TITLE
feat: Dagu integration — shellforge swarm + example DAGs

### DIFF
--- a/cmd/shellforge/main.go
+++ b/cmd/shellforge/main.go
@@ -47,6 +47,8 @@ fmt.Fprintln(os.Stderr, "Usage: shellforge agent \"your prompt\"")
 os.Exit(1)
 }
 cmdAgent(strings.Join(os.Args[2:], " "))
+case "swarm":
+cmdSwarm()
 case "serve":
 configPath := "agents.yaml"
 if len(os.Args) > 2 {
@@ -80,10 +82,11 @@ Usage:
   shellforge scan [dir]            DefenseClaw supply chain scan
   shellforge version               Print version
 
-  shellforge serve [config]       Daemon mode — run scheduled agent swarm
+  shellforge serve [config]       Simple daemon mode (built-in scheduler)
+  shellforge swarm                Setup Dagu orchestration (DAG workflows + web UI)
 
 Governance:  agentguard.yaml — every tool call evaluated before execution.
-Stack:       Ollama · AgentGuard · RTK
+Stack:       Ollama · AgentGuard · Dagu · RTK
 
 `, version)
 }
@@ -246,6 +249,78 @@ os.Exit(1)
 }
 printResult("prototype-agent", result)
 saveReport("outputs/logs", "prototype", result)
+}
+
+func cmdSwarm() {
+fmt.Println("=== ShellForge Swarm Setup (Dagu) ===")
+fmt.Println()
+
+// Check if Dagu is installed
+if _, err := exec.LookPath("dagu"); err != nil {
+fmt.Println("Dagu is not installed. Install it:")
+fmt.Println()
+if runtime.GOOS == "darwin" {
+fmt.Println("  brew install dagu")
+} else {
+fmt.Println("  curl -sL https://raw.githubusercontent.com/dagu-org/dagu/main/scripts/installer.sh | bash")
+}
+fmt.Println()
+fmt.Println("Then run 'shellforge swarm' again.")
+return
+}
+fmt.Println("✓ Dagu installed")
+
+// Check for dags directory
+if _, err := os.Stat("dags"); os.IsNotExist(err) {
+fmt.Println("→ Creating dags/ directory with example workflows...")
+os.MkdirAll("dags", 0o755)
+
+// Write SDLC swarm DAG
+sdlcDAG := `# sdlc-swarm.yaml — Daily SDLC agent swarm
+schedule: "0 9 * * *"
+
+steps:
+  - name: qa-analysis
+    command: shellforge agent "Analyze source code for test gaps and quality issues. Use read_file and list_files. Produce a structured report."
+
+  - name: security-scan
+    command: shellforge agent "Check for exposed secrets, insecure dependencies, and misconfigurations."
+    depends:
+      - qa-analysis
+
+  - name: daily-report
+    command: shellforge agent "Generate a daily status report from git log and previous agent findings."
+    depends:
+      - qa-analysis
+      - security-scan
+`
+os.WriteFile("dags/sdlc-swarm.yaml", []byte(sdlcDAG), 0o644)
+fmt.Println("  ✓ dags/sdlc-swarm.yaml (QA → security → report)")
+} else {
+fmt.Println("✓ dags/ directory exists")
+// Count DAGs
+entries, _ := filepath.Glob("dags/*.yaml")
+fmt.Printf("  %d DAG(s) found\n", len(entries))
+}
+
+// Check for governance
+configPath := findGovernanceConfig()
+if configPath == "" {
+fmt.Println("⚠ No agentguard.yaml — run 'shellforge setup' first")
+} else {
+fmt.Println("✓ Governance config found")
+}
+
+fmt.Println()
+fmt.Println("Start the swarm:")
+fmt.Println()
+fmt.Println("  dagu server --dags=./dags")
+fmt.Println()
+fmt.Println("Then open http://localhost:8080 for the dashboard.")
+fmt.Println()
+fmt.Println("Run a DAG now:")
+fmt.Println()
+fmt.Println("  dagu start dags/sdlc-swarm.yaml")
 }
 
 func cmdServe(configPath string) {

--- a/dags/README.md
+++ b/dags/README.md
@@ -1,0 +1,59 @@
+# ShellForge DAGs — Dagu Workflow Definitions
+
+Dagu orchestrates ShellForge agent runs as DAG workflows with scheduling, dependencies, retries, and a web dashboard.
+
+## Setup
+
+### Mac
+```bash
+brew install dagu
+```
+
+### Linux
+```bash
+curl -sL https://raw.githubusercontent.com/dagu-org/dagu/main/scripts/installer.sh | bash
+```
+
+## Usage
+
+```bash
+# Start Dagu server (web UI at http://localhost:8080)
+dagu server --dags=./dags
+
+# Run a specific DAG now
+dagu start dags/sdlc-swarm.yaml
+
+# Dry run (show what would execute)
+dagu dry dags/sdlc-swarm.yaml
+```
+
+## Available DAGs
+
+| DAG | Schedule | What It Does |
+|-----|----------|--------------|
+| `sdlc-swarm.yaml` | Daily 9am | QA analysis → security scan → daily report |
+| `studio-swarm.yaml` | Every 4h | Issues → tests → deps → health report |
+
+## Custom DAGs
+
+Create your own in this directory:
+
+```yaml
+# my-workflow.yaml
+schedule: "0 */6 * * *"  # every 6 hours
+
+steps:
+  - name: my-agent
+    command: shellforge agent "your task here"
+    dir: /path/to/your/repo
+```
+
+Every `shellforge agent` call is governed by `agentguard.yaml` in the target directory.
+
+## Dagu Dashboard
+
+Start with `dagu server --dags=./dags` and open http://localhost:8080 to see:
+- DAG execution history
+- Step-by-step logs
+- Retry controls
+- Schedule overview

--- a/dags/sdlc-swarm.yaml
+++ b/dags/sdlc-swarm.yaml
@@ -1,0 +1,34 @@
+# sdlc-swarm.yaml — Daily SDLC agent swarm
+# Runs QA, reporting, and security agents on a schedule.
+# Each step is governed by ShellForge (agentguard.yaml).
+#
+# Install Dagu: brew install dagu (Mac) or curl -sL https://dagu.sh | sh (Linux)
+# Run: dagu start dags/sdlc-swarm.yaml
+# Dashboard: http://localhost:8080
+
+schedule: "0 9 * * *"  # 9am daily
+
+params:
+  - REPO_DIR: .
+  - SHELLFORGE: shellforge
+
+steps:
+  - name: qa-analysis
+    command: ${SHELLFORGE} agent "Analyze the source code for test gaps, missing error handling, and code quality issues. Use read_file and list_files to examine the codebase. Produce a structured report with findings and recommendations."
+    dir: ${REPO_DIR}
+    output: QA_RESULT
+
+  - name: security-scan
+    command: ${SHELLFORGE} agent "Check this repository for security issues: exposed secrets in git history, insecure dependencies, hardcoded credentials, and misconfigured permissions. Use run_shell to check git log and list_files to find sensitive files."
+    dir: ${REPO_DIR}
+    depends:
+      - qa-analysis
+    output: SECURITY_RESULT
+
+  - name: daily-report
+    command: ${SHELLFORGE} agent "Generate a daily status report. Summarize: 1) Recent git commits (use run_shell for git log --oneline -20), 2) QA findings from the previous step, 3) Security scan results. Output as markdown."
+    dir: ${REPO_DIR}
+    depends:
+      - qa-analysis
+      - security-scan
+    output: REPORT

--- a/dags/studio-swarm.yaml
+++ b/dags/studio-swarm.yaml
@@ -1,0 +1,38 @@
+# studio-swarm.yaml — AgentGuard Studio project swarm
+# Continuous development agents for Studio projects.
+# Customize the REPO_DIR and prompts for each project.
+#
+# Run: dagu start dags/studio-swarm.yaml
+# Schedule: runs every 4 hours by default
+
+schedule: "0 */4 * * *"
+
+params:
+  - REPO_DIR: .
+  - SHELLFORGE: shellforge
+
+steps:
+  - name: check-issues
+    command: ${SHELLFORGE} agent "Check for open GitHub issues in this repo. Use run_shell with 'gh issue list --state open --limit 10'. Summarize the top priority issues."
+    dir: ${REPO_DIR}
+    output: ISSUES
+
+  - name: run-tests
+    command: ${SHELLFORGE} agent "Run the project's test suite. Use run_shell to detect the test command (go test, npm test, pytest, etc.) and run it. Report pass/fail counts and any failures."
+    dir: ${REPO_DIR}
+    output: TEST_RESULTS
+
+  - name: check-deps
+    command: ${SHELLFORGE} agent "Check for outdated dependencies. Use run_shell to run the appropriate command (go list -m -u all, npm outdated, pip list --outdated). Report any that need updating."
+    dir: ${REPO_DIR}
+    depends:
+      - run-tests
+    output: DEP_STATUS
+
+  - name: generate-report
+    command: ${SHELLFORGE} agent "Generate a project health report combining: open issues, test results, and dependency status. Format as markdown with sections for each area. Include a health score (healthy/warning/critical)."
+    dir: ${REPO_DIR}
+    depends:
+      - check-issues
+      - run-tests
+      - check-deps


### PR DESCRIPTION
## Summary
- `shellforge swarm` — setup wizard for Dagu orchestration
- Example DAGs: sdlc-swarm.yaml, studio-swarm.yaml
- Each DAG step calls `shellforge agent` with governance

## Usage
```bash
brew install dagu           # install orchestrator
shellforge swarm            # creates dags/ + example workflows
dagu server --dags=./dags   # start dashboard at :8080
dagu start dags/sdlc-swarm.yaml  # run now
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)